### PR TITLE
Fix unhandled error event for backend_ex connection.

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -128,10 +128,10 @@ function RedisBackend(conf) {
 
     self.redis.on('end', function() {
         self.emit('end');
+        backend_ex.quit();
     });
 
     self.disconnect = function() {
-        backend_ex.quit();
         self.redis.quit();
     };
 


### PR DESCRIPTION
Moved the quit command for backend_ex to run after the primary redis
connection is closed.